### PR TITLE
Eliminado classe Vendedor e usando import User

### DIFF
--- a/luiza_code/lu_marketplace/admin.py
+++ b/luiza_code/lu_marketplace/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from.models import Vendedor, Produto
+from.models import Produto
 
-admin.site.register(Vendedor)
 admin.site.register(Produto)

--- a/luiza_code/lu_marketplace/models.py
+++ b/luiza_code/lu_marketplace/models.py
@@ -1,15 +1,6 @@
 from django.db import models
 from django.db.models.deletion import CASCADE
-
-class Vendedor(models.Model):
-    vend_nome = models.CharField(max_length=100, verbose_name='Nome')
-    vend_email = models.EmailField(max_length=254, verbose_name='E-mail')
-
-    def __str__(self) -> str:
-        return self.vend_nome
-
-    
-
+from django.contrib.auth.models import User
 
 
 class Produto(models.Model):
@@ -19,7 +10,7 @@ class Produto(models.Model):
     prod_codigo = models.IntegerField(verbose_name='Código do Produto')
     prod_qtd = models.IntegerField(verbose_name='Quantidade')
     prod_inativo = models.BooleanField(default=False, verbose_name='Produto Inativo')
-    vend_id = models.ForeignKey(Vendedor, on_delete=CASCADE, verbose_name='Vendedor')
+    vend_id = models.ForeignKey(User, on_delete=CASCADE, verbose_name='Vendedor')
 
     def __str__(self) -> str:
         return self.prod_nome


### PR DESCRIPTION
Elimando a classe Vendedor criada anteriormente e usando o import User do próprio Django. Agora na classe produto, a variável vend_id é a chave estrangeira de User.